### PR TITLE
Chore ignore no countries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ cache:
     - $HOME/.composer/cache
 
 php:
- - 5.4
+ - 7.3
 
 env:
  global:
-  - MOODLE_BRANCH=MOODLE_30_STABLE
+  - MOODLE_BRANCH=MOODLE_39_STABLE
   - IGNORE_PATHS=js,css
  matrix:
   - DB=mysqli

--- a/lang/en/block_usersmap.php
+++ b/lang/en/block_usersmap.php
@@ -69,3 +69,6 @@ $string['scheduled_task_title'] = 'Update users geographical coordinates';
 $string['scheduled_task_title_all'] = 'Update users geographical coordinates (ALL)';
 $string['scheduled_task_start_message'] = 'Updating users geographical coordinates';
 $string['scheduled_task_start_message_all'] = 'Updating users geographical coordinates (ALL)';
+
+$string['countriesmissing_text'] = 'Allow countries missing';
+$string['countriesmissing_text_desc'] = 'If this option is checked, the plugin will also process data that does not have a country defined';

--- a/lang/fr/block_usersmap.php
+++ b/lang/fr/block_usersmap.php
@@ -69,3 +69,6 @@ $string['scheduled_task_title'] = 'Mise à jour des coordonnées géographiques 
 $string['scheduled_task_title_all'] = 'Mise à jour des coordonnées géographiques des utilisateurs (TOUS)';
 $string['scheduled_task_start_message'] = 'Mise à jour des coordonnées géographiques des utilisateurs !';
 $string['scheduled_task_start_message_all'] = 'Mise à jour des coordonnées géographiques des utilisateurs (TOUS)';
+
+$string['countriesmissing_text'] = 'Autoriser pays manquants';
+$string['countriesmissing_text_desc'] = 'Si cette option est coché, le plugin traitera également les données n\'ayant pas de pays défini';

--- a/settings.php
+++ b/settings.php
@@ -115,3 +115,12 @@ $settings->add(new admin_setting_configtext(
     get_string('tileserver_attribution_text_desc', 'block_usersmap'),
     ''
 ));
+// Setting that allows to define if we want to ignore or not the data having no defined country.
+$settings->add(new admin_setting_configcheckbox(
+        'usersmap/countriesmissing',
+        get_string('countriesmissing_text', 'block_usersmap'),
+        get_string('countriesmissing_text_desc', 'block_usersmap'),
+        false,
+        true,
+        false
+));

--- a/version.php
+++ b/version.php
@@ -31,4 +31,4 @@ $plugin->component = 'block_usersmap';
 $plugin->version = 2020080204;
 $plugin->requires = 2014111000; // Moodle v2.8.
 $plugin->maturity = MATURITY_BETA;
-$plugin->release = "1.1";
+$plugin->release = "1.4";

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->component = 'block_usersmap';
-$plugin->version = 2016052615;
+$plugin->version = 2020080204;
 $plugin->requires = 2014111000; // Moodle v2.8.
 $plugin->maturity = MATURITY_BETA;
-$plugin->release = "0.2";
+$plugin->release = "1.1";


### PR DESCRIPTION
- It is recommended to use the {tablename} syntax when making requests on the database.
- Add a new setting that allows to define if we want to ignore or not the data having no defined country.
- Also made some changes on Travis config ( php --> 7.3 and branch --> MOODLE_39_STABLE )

I didn't modify the basic behavior concerning the recording of data in database but only the relative display on the map.

The option is set by default to "false", this will therefore have the consequence of ignoring the data having no country defined.

This will be merged tomorow and deployed on the test server :)

Closes #1 